### PR TITLE
Fix bug when supplying get_urls in POST

### DIFF
--- a/functions/api_flow_segments/app.py
+++ b/functions/api_flow_segments/app.py
@@ -352,18 +352,17 @@ def filter_object_urls(schema_items: list, accept_get_urls: str) -> None:
     for item in schema_items:
         if accept_get_urls == "":
             item.get_urls = None
-        else:
-            get_url = get_nonsigned_url(item.object_id)
-            if item.get_urls is None:
-                item.get_urls = [get_url]
-            else:
-                item.get_urls.append(get_url)
-            if item.object_id in presigned_urls:
-                presigned_get_url = GetUrl(
-                    label=f"aws.{bucket_region}:s3.presigned:{store_name}",
-                    url=presigned_urls[item.object_id],
-                )
-                item.get_urls.append(presigned_get_url)
+            continue
+        get_url = get_nonsigned_url(item.object_id)
+        item.get_urls = [*item.get_urls, get_url] if item.get_urls else [get_url]
+        # Add pre-signed urls where supplied
+        if item.object_id in presigned_urls:
+            presigned_get_url = GetUrl(
+                label=f"aws.{bucket_region}:s3.presigned:{store_name}",
+                url=presigned_urls[item.object_id],
+            )
+            item.get_urls.append(presigned_get_url)
+        # Filter returned get_urls when specified
         if accept_get_urls:
             get_url_labels = [
                 label for label in accept_get_urls.split(",") if label.strip()

--- a/functions/api_flow_segments/app.py
+++ b/functions/api_flow_segments/app.py
@@ -174,11 +174,12 @@ def post_flow_segments_by_id(
         raise BadRequestError(
             "Bad request. Invalid flow storage request JSON or the flow 'container' is not set."
         )  # 400
-    if not flow_segment.get_urls:
-        if not check_object_exists(bucket, flow_segment.object_id):
-            raise BadRequestError(
-                "Bad request. The object id provided for a segment MUST exist."
-            )  # 400
+    if not flow_segment.get_urls and not check_object_exists(
+        bucket, flow_segment.object_id
+    ):
+        raise BadRequestError(
+            "Bad request. The object id provided for a segment MUST exist."
+        )  # 400
     item_dict = model_dump(flow_segment)
     segment_timerange = TimeRange.from_str(item_dict["timerange"])
     if check_overlapping_segments(flow_id, segment_timerange):


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This issue fixes 2 related bugs:
- When POSTing a segment and supplying get-urls (due to using external storage) the API incorrectly reports the object must exist in S3
- When get_urls are already present on a segment object the GET request fails due to incorrect code logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
