### PR TITLE
Feat/neptune upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The first command will build the source of your application. The second command 
 - **VpcId**: Specify an existing VPC Id, leave blank to have one created.
 - **VpcAZs**: Specify a comma-separated list of availability zones (for example `us-east-1a,us-east-1b`) to use when a VPC is specified. The number of AZs must match the number of private subnets specified in PrivateSubnetIds. Leave blank if VPC being created.
 - **PrivateSubnetIds**: Specify a comma-delimited list of the Private Subnet Ids to be used in the existing VPC.
+- **NeptuneDBInstanceClass**: Neptune Cluster Instance class, for example `db.serverless` or `db.r7g.large`
 - **NeptuneServerlessConfiguration**: Neptune Serverless Scaling Configuration. Must be a list of two values, MinCapacity and MaxCapacity, separated by commas. Valid values between 1–128.
 - **DeployWaf**: Specify whether you want the solution behind a WAF.
 - **Confirm changes before deploy**: If set to yes, any change sets will be shown to you before execution for manual review. If set to no, the AWS SAM CLI will automatically deploy application changes.

--- a/template.yaml
+++ b/template.yaml
@@ -28,6 +28,12 @@ Parameters:
     Default: ""
     AllowedPattern: '|subnet-[a-z0-9]+'
 
+  NeptuneDBInstanceClass:
+    Description: The DBInstanceClass to be used for the Neptune Database
+    Type: String
+    Default: db.serverless
+    AllowedPattern: ^db\.(serverless|[a-z0-9]+\.[a-z0-9]+)$
+
   NeptuneServerlessConfiguration:
     Description: Neptune Serverless Scaling Configuration.
     Type: String
@@ -47,7 +53,7 @@ Mappings:
   Solution:
     Constants:
       ApiVersion: "7.0"
-      ServiceVersion: "4.0"
+      ServiceVersion: "4.1"
 
   OAuth:
     Scopes:
@@ -1977,6 +1983,7 @@ Resources:
         PrivateSubnetIds: !If [CreateVpc, !GetAtt VpcStack.Outputs.PrivateSubnetIds, !Join [',', !Ref PrivateSubnetIds]]
         LambdaSecurityGroupId: !Ref LambdaSecurityGroup
         ServerlessScalingConfiguration: !Ref NeptuneServerlessConfiguration
+        DBInstanceClass: !Ref NeptuneDBInstanceClass
 
   WafStack:
     Type: AWS::CloudFormation::Stack

--- a/templates/neptune.yaml
+++ b/templates/neptune.yaml
@@ -20,12 +20,22 @@ Parameters:
     Description: Lambda Security Group ID
     Type: AWS::EC2::SecurityGroup::Id
 
+  DBInstanceClass:
+    Description: The DBInstanceClass to be used for the Neptune Database
+    Type: String
+    Default: db.serverless
+    AllowedPattern: ^db\.(serverless|[a-z0-9]+\.[a-z0-9]+)$
+
   ServerlessScalingConfiguration:
     Description: Neptune Serverless Scaling Configuration.
     Type: String
     ConstraintDescription: "ServerlessScalingConfiguration must be a list of two values, MinCapacity and MaxCapacity, separated by commas. Valid values between 1-128."
     AllowedPattern: (12[0-8]|1[01][0-9]|[1-9][0-9]|[1-9]),(12[0-8]|1[01][0-9]|[1-9][0-9]|[1-9])
     Default: 1,128
+
+Conditions:
+
+  CreateServerless: !Equals [!Ref DBInstanceClass, "db.serverless"]
 
 Resources:
 
@@ -63,14 +73,16 @@ Resources:
       StorageEncrypted: True
       VpcSecurityGroupIds:
         - !Ref NeptuneSecurityGroup
-      ServerlessScalingConfiguration:
-        MinCapacity: !Select [0, !Split [",", !Ref ServerlessScalingConfiguration]]
-        MaxCapacity: !Select [1, !Split [",", !Ref ServerlessScalingConfiguration]]
+      ServerlessScalingConfiguration: !If
+        - CreateServerless
+        - MinCapacity: !Select [0, !Split [",", !Ref ServerlessScalingConfiguration]]
+          MaxCapacity: !Select [1, !Split [",", !Ref ServerlessScalingConfiguration]]
+        - !Ref AWS::NoValue
 
   TAMSNeptuneInstance:
     Type: AWS::Neptune::DBInstance
     Properties:
-      DBInstanceClass: db.serverless
+      DBInstanceClass: !Ref DBInstanceClass
       DBClusterIdentifier: !Ref TAMSNeptuneCluster
 
 Outputs:

--- a/templates/neptune.yaml
+++ b/templates/neptune.yaml
@@ -68,7 +68,7 @@ Resources:
     Properties:
       AvailabilityZones: !Ref VpcAZs
       DBSubnetGroupName: !Ref DBSubnetGroup
-      EngineVersion: 1.3.4.0
+      EngineVersion: 1.4.5.1
       IamAuthEnabled: True
       StorageEncrypted: True
       VpcSecurityGroupIds:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import boto3
 import pytest
 import requests
+from deepdiff import DeepDiff
 
 STACK_NAME = os.environ["TAMS_STACK_NAME"]
 REGION = os.environ["TAMS_REGION"]
@@ -318,3 +319,10 @@ def get_client_secret(session, user_pool_id, client_id, client_region):
         UserPoolId=user_pool_id, ClientId=client_id
     )
     return user_pool_client["UserPoolClient"]["ClientSecret"]
+
+
+def assert_equal_unordered(obj1, obj2):
+    """Assert that two objects are equal, ignoring order of lists and sets."""
+    diff = DeepDiff(obj1, obj2, ignore_order=True)
+    if diff:
+        raise AssertionError(f"Objects are not equal:\n{diff}")

--- a/tests/acceptance/test_02_flows.py
+++ b/tests/acceptance/test_02_flows.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-lines
 import pytest
 import requests
+from deepdiff import DeepDiff
 
 pytestmark = [
     pytest.mark.acceptance,
@@ -83,7 +84,7 @@ def test_Create_or_Replace_Flow_PUT_201_VIDEO(api_client_cognito, stub_video_flo
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert stub_video_flow == response_json
+    assert not DeepDiff(stub_video_flow, response_json, ignore_order=True)
 
 
 def test_Create_or_Replace_Flow_PUT_201_AUDIO(api_client_cognito, stub_audio_flow):
@@ -104,7 +105,7 @@ def test_Create_or_Replace_Flow_PUT_201_AUDIO(api_client_cognito, stub_audio_flo
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert stub_audio_flow == response_json
+    assert not DeepDiff(stub_audio_flow, response_json, ignore_order=True)
 
 
 def test_Create_or_Replace_Flow_PUT_201_DATA(api_client_cognito, stub_data_flow):
@@ -125,7 +126,7 @@ def test_Create_or_Replace_Flow_PUT_201_DATA(api_client_cognito, stub_data_flow)
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert stub_data_flow == response_json
+    assert not DeepDiff(stub_data_flow, response_json, ignore_order=True)
 
 
 def test_Create_or_Replace_Flow_PUT_201_IMAGE(api_client_cognito, stub_image_flow):
@@ -146,7 +147,7 @@ def test_Create_or_Replace_Flow_PUT_201_IMAGE(api_client_cognito, stub_image_flo
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert stub_image_flow == response_json
+    assert not DeepDiff(stub_image_flow, response_json, ignore_order=True)
 
 
 def test_Create_or_Replace_Flow_PUT_201_MULTI(api_client_cognito, stub_multi_flow):
@@ -167,7 +168,7 @@ def test_Create_or_Replace_Flow_PUT_201_MULTI(api_client_cognito, stub_multi_flo
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert stub_multi_flow == response_json
+    assert not DeepDiff(stub_multi_flow, response_json, ignore_order=True)
 
 
 def test_Create_or_Replace_Flow_PUT_204(api_client_cognito, stub_multi_flow):
@@ -648,9 +649,11 @@ def test_List_Flows_GET_200_codec(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [
-        {**stub_audio_flow, "collected_by": [stub_multi_flow["id"]]}
-    ] == response_json
+    assert not DeepDiff(
+        [{**stub_audio_flow, "collected_by": [stub_multi_flow["id"]]}],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Flows_GET_200_format(
@@ -674,9 +677,11 @@ def test_List_Flows_GET_200_format(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [
-        {**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}
-    ] == response_json
+    assert not DeepDiff(
+        [{**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Flows_GET_200_frame_height(
@@ -698,9 +703,11 @@ def test_List_Flows_GET_200_frame_height(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [
-        {**stub_video_flow, "collected_by": [stub_multi_flow["id"]]}
-    ] == response_json
+    assert not DeepDiff(
+        [{**stub_video_flow, "collected_by": [stub_multi_flow["id"]]}],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Flows_GET_200_frame_width(
@@ -722,9 +729,11 @@ def test_List_Flows_GET_200_frame_width(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [
-        {**stub_video_flow, "collected_by": [stub_multi_flow["id"]]}
-    ] == response_json
+    assert not DeepDiff(
+        [{**stub_video_flow, "collected_by": [stub_multi_flow["id"]]}],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Flows_GET_200_label(api_client_cognito, dynamic_props, stub_multi_flow):
@@ -749,7 +758,11 @@ def test_List_Flows_GET_200_label(api_client_cognito, dynamic_props, stub_multi_
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [stub_multi_flow] == response_json
+    assert not DeepDiff(
+        [stub_multi_flow],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Flows_GET_200_limit(api_client_cognito):
@@ -804,9 +817,11 @@ def test_List_Flows_GET_200_source_id(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [
-        {**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}
-    ] == response_json
+    assert not DeepDiff(
+        [{**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Flows_GET_200_tag_name(
@@ -833,7 +848,11 @@ def test_List_Flows_GET_200_tag_name(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [stub_multi_flow] == response_json
+    assert not DeepDiff(
+        [stub_multi_flow],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Flows_GET_200_tag_exists_name(api_client_cognito):
@@ -1221,7 +1240,11 @@ def test_Flow_Details_GET_200(
     for prop in dynamic_props:
         if prop in response_json:
             del response_json[prop]
-    assert {**stub_data_flow, "collected_by": [stub_multi_flow["id"]]} == response_json
+    assert not DeepDiff(
+        {**stub_data_flow, "collected_by": [stub_multi_flow["id"]]},
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_Flow_Details_GET_400(api_client_cognito, stub_data_flow):
@@ -2043,7 +2066,11 @@ def test_Flow_Flow_Collection_GET_200(api_client_cognito, stub_multi_flow):
     assert 200 == response.status_code
     assert "content-type" in response_headers_lower
     assert "application/json" == response_headers_lower["content-type"]
-    assert stub_multi_flow["flow_collection"] == response_json
+    assert not DeepDiff(
+        stub_multi_flow["flow_collection"],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_Flow_Flow_Collection_GET_404(api_client_cognito, id_404):

--- a/tests/acceptance/test_02_flows.py
+++ b/tests/acceptance/test_02_flows.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-lines
 import pytest
 import requests
-from deepdiff import DeepDiff
+from conftest import assert_equal_unordered
 
 pytestmark = [
     pytest.mark.acceptance,
@@ -84,7 +84,7 @@ def test_Create_or_Replace_Flow_PUT_201_VIDEO(api_client_cognito, stub_video_flo
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert not DeepDiff(stub_video_flow, response_json, ignore_order=True)
+    assert_equal_unordered(stub_video_flow, response_json)
 
 
 def test_Create_or_Replace_Flow_PUT_201_AUDIO(api_client_cognito, stub_audio_flow):
@@ -105,7 +105,7 @@ def test_Create_or_Replace_Flow_PUT_201_AUDIO(api_client_cognito, stub_audio_flo
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert not DeepDiff(stub_audio_flow, response_json, ignore_order=True)
+    assert_equal_unordered(stub_audio_flow, response_json)
 
 
 def test_Create_or_Replace_Flow_PUT_201_DATA(api_client_cognito, stub_data_flow):
@@ -126,7 +126,7 @@ def test_Create_or_Replace_Flow_PUT_201_DATA(api_client_cognito, stub_data_flow)
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert not DeepDiff(stub_data_flow, response_json, ignore_order=True)
+    assert_equal_unordered(stub_data_flow, response_json)
 
 
 def test_Create_or_Replace_Flow_PUT_201_IMAGE(api_client_cognito, stub_image_flow):
@@ -147,7 +147,7 @@ def test_Create_or_Replace_Flow_PUT_201_IMAGE(api_client_cognito, stub_image_flo
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert not DeepDiff(stub_image_flow, response_json, ignore_order=True)
+    assert_equal_unordered(stub_image_flow, response_json)
 
 
 def test_Create_or_Replace_Flow_PUT_201_MULTI(api_client_cognito, stub_multi_flow):
@@ -168,7 +168,7 @@ def test_Create_or_Replace_Flow_PUT_201_MULTI(api_client_cognito, stub_multi_flo
     for prop in ["created_by", "created"]:
         assert prop in response_json
         del response_json[prop]
-    assert not DeepDiff(stub_multi_flow, response_json, ignore_order=True)
+    assert_equal_unordered(stub_multi_flow, response_json)
 
 
 def test_Create_or_Replace_Flow_PUT_204(api_client_cognito, stub_multi_flow):
@@ -649,10 +649,8 @@ def test_List_Flows_GET_200_codec(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [{**stub_audio_flow, "collected_by": [stub_multi_flow["id"]]}],
-        response_json,
-        ignore_order=True,
+    assert_equal_unordered(
+        [{**stub_audio_flow, "collected_by": [stub_multi_flow["id"]]}], response_json
     )
 
 
@@ -677,10 +675,8 @@ def test_List_Flows_GET_200_format(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [{**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}],
-        response_json,
-        ignore_order=True,
+    assert_equal_unordered(
+        [{**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}], response_json
     )
 
 
@@ -703,10 +699,8 @@ def test_List_Flows_GET_200_frame_height(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [{**stub_video_flow, "collected_by": [stub_multi_flow["id"]]}],
-        response_json,
-        ignore_order=True,
+    assert_equal_unordered(
+        [{**stub_video_flow, "collected_by": [stub_multi_flow["id"]]}], response_json
     )
 
 
@@ -729,10 +723,8 @@ def test_List_Flows_GET_200_frame_width(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [{**stub_video_flow, "collected_by": [stub_multi_flow["id"]]}],
-        response_json,
-        ignore_order=True,
+    assert_equal_unordered(
+        [{**stub_video_flow, "collected_by": [stub_multi_flow["id"]]}], response_json
     )
 
 
@@ -758,11 +750,7 @@ def test_List_Flows_GET_200_label(api_client_cognito, dynamic_props, stub_multi_
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [stub_multi_flow],
-        response_json,
-        ignore_order=True,
-    )
+    assert_equal_unordered([stub_multi_flow], response_json)
 
 
 def test_List_Flows_GET_200_limit(api_client_cognito):
@@ -817,10 +805,8 @@ def test_List_Flows_GET_200_source_id(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [{**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}],
-        response_json,
-        ignore_order=True,
+    assert_equal_unordered(
+        [{**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}], response_json
     )
 
 
@@ -848,11 +834,7 @@ def test_List_Flows_GET_200_tag_name(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [stub_multi_flow],
-        response_json,
-        ignore_order=True,
-    )
+    assert_equal_unordered([stub_multi_flow], response_json)
 
 
 def test_List_Flows_GET_200_tag_exists_name(api_client_cognito):
@@ -1240,10 +1222,8 @@ def test_Flow_Details_GET_200(
     for prop in dynamic_props:
         if prop in response_json:
             del response_json[prop]
-    assert not DeepDiff(
-        {**stub_data_flow, "collected_by": [stub_multi_flow["id"]]},
-        response_json,
-        ignore_order=True,
+    assert_equal_unordered(
+        {**stub_data_flow, "collected_by": [stub_multi_flow["id"]]}, response_json
     )
 
 
@@ -2066,11 +2046,7 @@ def test_Flow_Flow_Collection_GET_200(api_client_cognito, stub_multi_flow):
     assert 200 == response.status_code
     assert "content-type" in response_headers_lower
     assert "application/json" == response_headers_lower["content-type"]
-    assert not DeepDiff(
-        stub_multi_flow["flow_collection"],
-        response_json,
-        ignore_order=True,
-    )
+    assert_equal_unordered(stub_multi_flow["flow_collection"], response_json)
 
 
 def test_Flow_Flow_Collection_GET_404(api_client_cognito, id_404):

--- a/tests/acceptance/test_03_sources.py
+++ b/tests/acceptance/test_03_sources.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-lines
 import pytest
 import requests
+from deepdiff import DeepDiff
 
 pytestmark = [
     pytest.mark.acceptance,
@@ -323,9 +324,11 @@ def test_List_Sources_GET_200_format(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [
-        {**stub_data_source, "collected_by": [stub_multi_source["id"]]}
-    ] == response_json
+    assert not DeepDiff(
+        [{**stub_data_source, "collected_by": [stub_multi_source["id"]]}],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Sources_GET_200_label(
@@ -356,7 +359,11 @@ def test_List_Sources_GET_200_label(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [stub_multi_source] == response_json
+    assert not DeepDiff(
+        [stub_multi_source],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Sources_GET_200_limit(api_client_cognito):
@@ -426,7 +433,11 @@ def test_List_Sources_GET_200_tag_name(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert [stub_multi_source] == response_json
+    assert not DeepDiff(
+        [stub_multi_source],
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Sources_GET_200_tag_exists_name(api_client_cognito):
@@ -630,10 +641,14 @@ def test_Source_Details_GET_200(
     for prop in dynamic_props:
         if prop in response_json:
             del response_json[prop]
-    assert {
-        **stub_data_source,
-        "collected_by": [stub_multi_source["id"]],
-    } == response_json
+    assert not DeepDiff(
+        {
+            **stub_data_source,
+            "collected_by": [stub_multi_source["id"]],
+        },
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_Source_Details_GET_404(api_client_cognito, id_404):

--- a/tests/acceptance/test_03_sources.py
+++ b/tests/acceptance/test_03_sources.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-lines
 import pytest
 import requests
-from deepdiff import DeepDiff
+from conftest import assert_equal_unordered
 
 pytestmark = [
     pytest.mark.acceptance,
@@ -324,10 +324,8 @@ def test_List_Sources_GET_200_format(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [{**stub_data_source, "collected_by": [stub_multi_source["id"]]}],
-        response_json,
-        ignore_order=True,
+    assert_equal_unordered(
+        [{**stub_data_source, "collected_by": [stub_multi_source["id"]]}], response_json
     )
 
 
@@ -359,11 +357,7 @@ def test_List_Sources_GET_200_label(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [stub_multi_source],
-        response_json,
-        ignore_order=True,
-    )
+    assert_equal_unordered([stub_multi_source], response_json)
 
 
 def test_List_Sources_GET_200_limit(api_client_cognito):
@@ -433,11 +427,7 @@ def test_List_Sources_GET_200_tag_name(
         for record in response_json:
             if prop in record:
                 del record[prop]
-    assert not DeepDiff(
-        [stub_multi_source],
-        response_json,
-        ignore_order=True,
-    )
+    assert_equal_unordered([stub_multi_source], response_json)
 
 
 def test_List_Sources_GET_200_tag_exists_name(api_client_cognito):
@@ -641,13 +631,8 @@ def test_Source_Details_GET_200(
     for prop in dynamic_props:
         if prop in response_json:
             del response_json[prop]
-    assert not DeepDiff(
-        {
-            **stub_data_source,
-            "collected_by": [stub_multi_source["id"]],
-        },
-        response_json,
-        ignore_order=True,
+    assert_equal_unordered(
+        {**stub_data_source, "collected_by": [stub_multi_source["id"]]}, response_json
     )
 
 

--- a/tests/acceptance/test_04_segments.py
+++ b/tests/acceptance/test_04_segments.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 import requests
-from deepdiff import DeepDiff
+from conftest import assert_equal_unordered
 
 pytestmark = [
     pytest.mark.acceptance,
@@ -879,7 +879,7 @@ def test_Flow_Details_GET_200_timerange(
     for prop in dynamic_props:
         if prop in response_json:
             del response_json[prop]
-    assert not DeepDiff(
+    assert_equal_unordered(
         {
             **stub_video_flow,
             "label": "pytest",
@@ -890,7 +890,6 @@ def test_Flow_Details_GET_200_timerange(
             "max_bit_rate": 6000000,
         },
         response_json,
-        ignore_order=True,
     )
 
 

--- a/tests/acceptance/test_04_segments.py
+++ b/tests/acceptance/test_04_segments.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 import requests
+from deepdiff import DeepDiff
 
 pytestmark = [
     pytest.mark.acceptance,
@@ -878,15 +879,19 @@ def test_Flow_Details_GET_200_timerange(
     for prop in dynamic_props:
         if prop in response_json:
             del response_json[prop]
-    assert {
-        **stub_video_flow,
-        "label": "pytest",
-        "description": "pytest",
-        "collected_by": [stub_multi_flow["id"]],
-        "timerange": "[1:0_3:0)",
-        "avg_bit_rate": 6000000,
-        "max_bit_rate": 6000000,
-    } == response_json
+    assert not DeepDiff(
+        {
+            **stub_video_flow,
+            "label": "pytest",
+            "description": "pytest",
+            "collected_by": [stub_multi_flow["id"]],
+            "timerange": "[1:0_3:0)",
+            "avg_bit_rate": 6000000,
+            "max_bit_rate": 6000000,
+        },
+        response_json,
+        ignore_order=True,
+    )
 
 
 def test_List_Flows_GET_200_timerange_eternity(api_client_cognito):


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This PR adds the the ability for Neptune DB to be specified as provisioned as well as Serverless. This was done to address the "cold start" issues encountered with low usage Serverless implementations but of course will have an impact of cost.
Also updated Neptune version from 1.3.4.0 to 1.4.5.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
