### PR TITLE
bug fix: Flow update with complex type properties

### DIFF
--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -14,6 +14,7 @@ from schema import Flowcollection, Source
 from utils import (
     deserialise_neptune_obj,
     filter_dict,
+    get_default_value,
     model_dump,
     parse_api_gw_parameters,
     publish_event,
@@ -488,7 +489,7 @@ def merge_flow(flow_dict: dict, existing_dict: dict) -> dict:
             - essence_parameters.keys()
         }
         null_properties = {
-            k: None
+            k: get_default_value(existing_dict[k])
             for k in (
                 existing_dict.keys()
                 - {

--- a/layers/utils/utils.py
+++ b/layers/utils/utils.py
@@ -232,8 +232,8 @@ def serialise_neptune_obj(obj: dict, key_prefix: str = "") -> dict:
     serialised = {}
     for k, v in obj.items():
         if isinstance(v, (list, dict)):
-            serialised[f"{key_prefix}{constants.SERIALISE_PREFIX}{k}"] = json.dumps(
-                v, default=json_number
+            serialised[f"{key_prefix}{constants.SERIALISE_PREFIX}{k}"] = (
+                json.dumps(v, default=json_number) if v else None
             )
         else:
             serialised[f"{key_prefix}{k}"] = v
@@ -348,3 +348,14 @@ def generate_failed_segment(
             },
         }
     )
+
+
+@tracer.capture_method(capture_response=False)
+def get_default_value(value) -> dict | list | None:
+    """Return appropriate default value based on input type."""
+    if isinstance(value, dict):
+        return {}
+    elif isinstance(value, list):
+        return []
+    else:
+        return None


### PR DESCRIPTION
*Issue #, if available:*
Due to the way that complex properties are being stored in Neptune (as serialised strings) there was a bug if/when a client attempted to remove those properties from the Flow. The requested action was not happening.
This PR fixes this bug by correctly setting the "empty" type for the property and detecting this to be Null in the Neptune SET expression.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
