### PR TITLE
fix bug with dots and other special chars in the tag name

### DIFF
--- a/functions/api_flows/app.py
+++ b/functions/api_flows/app.py
@@ -69,11 +69,11 @@ from utils import (
     generate_presigned_url,
     get_username,
     model_dump,
+    opencypher_property_name,
     parse_claims,
     parse_tag_parameters,
     publish_event,
     put_message,
-    safe_property_name,
 )
 
 tracer = Tracer()
@@ -341,7 +341,10 @@ def put_flow_tag_value(
         )  # 403
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, flow_id, username, {f"t.{safe_property_name(tag_name)}": tag_value}
+        record_type,
+        flow_id,
+        username,
+        {f"t.{opencypher_property_name(tag_name)}": tag_value},
     )
     publish_event(
         f"{record_type}s/updated",
@@ -372,7 +375,10 @@ def delete_flow_tag_value(
         raise NotFoundError("The requested flow ID in the path is invalid.")  # 404
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, flow_id, username, {f"t.{safe_property_name(tag_name)}": None}
+        record_type,
+        flow_id,
+        username,
+        {f"t.{opencypher_property_name(tag_name)}": None},
     )
     publish_event(
         f"{record_type}s/updated",

--- a/functions/api_flows/app.py
+++ b/functions/api_flows/app.py
@@ -340,7 +340,7 @@ def put_flow_tag_value(
         )  # 403
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, flow_id, username, {f"t.{tag_name}": tag_value}
+        record_type, flow_id, username, {f"t.`{tag_name}`": tag_value}
     )
     publish_event(
         f"{record_type}s/updated",
@@ -371,7 +371,7 @@ def delete_flow_tag_value(
         raise NotFoundError("The requested flow ID in the path is invalid.")  # 404
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, flow_id, username, {f"t.{tag_name}": None}
+        record_type, flow_id, username, {f"t.`{tag_name}`": None}
     )
     publish_event(
         f"{record_type}s/updated",

--- a/functions/api_flows/app.py
+++ b/functions/api_flows/app.py
@@ -73,6 +73,7 @@ from utils import (
     parse_tag_parameters,
     publish_event,
     put_message,
+    safe_property_name,
 )
 
 tracer = Tracer()
@@ -340,7 +341,7 @@ def put_flow_tag_value(
         )  # 403
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, flow_id, username, {f"t.`{tag_name}`": tag_value}
+        record_type, flow_id, username, {f"t.{safe_property_name(tag_name)}": tag_value}
     )
     publish_event(
         f"{record_type}s/updated",
@@ -371,7 +372,7 @@ def delete_flow_tag_value(
         raise NotFoundError("The requested flow ID in the path is invalid.")  # 404
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, flow_id, username, {f"t.`{tag_name}`": None}
+        record_type, flow_id, username, {f"t.{safe_property_name(tag_name)}": None}
     )
     publish_event(
         f"{record_type}s/updated",

--- a/functions/api_sources/app.py
+++ b/functions/api_sources/app.py
@@ -37,6 +37,7 @@ from utils import (
     parse_claims,
     parse_tag_parameters,
     publish_event,
+    safe_property_name,
 )
 
 tracer = Tracer()
@@ -156,7 +157,10 @@ def put_source_tag_value(
         )  # 404
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, source_id, username, {f"t.`{tag_name}`": tag_value}
+        record_type,
+        source_id,
+        username,
+        {f"t.{safe_property_name(tag_name)}": tag_value},
     )
     publish_event(
         f"{record_type}s/updated",
@@ -184,7 +188,7 @@ def delete_source_tag(
         )  # 404
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, source_id, username, {f"t.`{tag_name}`": None}
+        record_type, source_id, username, {f"t.{safe_property_name(tag_name)}": None}
     )
     publish_event(
         f"{record_type}s/updated",

--- a/functions/api_sources/app.py
+++ b/functions/api_sources/app.py
@@ -156,7 +156,7 @@ def put_source_tag_value(
         )  # 404
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, source_id, username, {f"t.{tag_name}": tag_value}
+        record_type, source_id, username, {f"t.`{tag_name}`": tag_value}
     )
     publish_event(
         f"{record_type}s/updated",
@@ -184,7 +184,7 @@ def delete_source_tag(
         )  # 404
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, source_id, username, {f"t.{tag_name}": None}
+        record_type, source_id, username, {f"t.`{tag_name}`": None}
     )
     publish_event(
         f"{record_type}s/updated",

--- a/functions/api_sources/app.py
+++ b/functions/api_sources/app.py
@@ -34,10 +34,10 @@ from utils import (
     generate_link_url,
     get_username,
     model_dump,
+    opencypher_property_name,
     parse_claims,
     parse_tag_parameters,
     publish_event,
-    safe_property_name,
 )
 
 tracer = Tracer()
@@ -160,7 +160,7 @@ def put_source_tag_value(
         record_type,
         source_id,
         username,
-        {f"t.{safe_property_name(tag_name)}": tag_value},
+        {f"t.{opencypher_property_name(tag_name)}": tag_value},
     )
     publish_event(
         f"{record_type}s/updated",
@@ -188,7 +188,10 @@ def delete_source_tag(
         )  # 404
     username = get_username(parse_claims(app.current_event.request_context))
     item_dict = set_node_property(
-        record_type, source_id, username, {f"t.{safe_property_name(tag_name)}": None}
+        record_type,
+        source_id,
+        username,
+        {f"t.{opencypher_property_name(tag_name)}": None},
     )
     publish_event(
         f"{record_type}s/updated",

--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -16,9 +16,9 @@ from utils import (
     filter_dict,
     get_default_value,
     model_dump,
+    opencypher_property_name,
     parse_api_gw_parameters,
     publish_event,
-    safe_property_name,
     serialise_neptune_obj,
 )
 
@@ -295,7 +295,7 @@ def query_node_property(record_type: str, record_id: str, prop_name: str) -> any
         query = (
             qb.match()
             .node(ref_name="n", labels=record_type, properties={"id": record_id})
-            .return_literal(f"n.{safe_property_name(prop_name)} AS property")
+            .return_literal(f"n.{opencypher_property_name(prop_name)} AS property")
             .get()
         )
         results = neptune.execute_open_cypher_query(openCypherQuery=query)
@@ -825,5 +825,5 @@ def generate_flow_collection_query(
     # Build the dict of set operations to carry out
     for _, c_ref, _, props in ref_names:
         for k, v in props.items():
-            set_dict[f"{c_ref}.{safe_property_name(k)}"] = v
+            set_dict[f"{c_ref}.{opencypher_property_name(k)}"] = v
     return query.set(set_dict)

--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -18,6 +18,7 @@ from utils import (
     model_dump,
     parse_api_gw_parameters,
     publish_event,
+    safe_property_name,
     serialise_neptune_obj,
 )
 
@@ -294,7 +295,7 @@ def query_node_property(record_type: str, record_id: str, prop_name: str) -> any
         query = (
             qb.match()
             .node(ref_name="n", labels=record_type, properties={"id": record_id})
-            .return_literal(f"n.{prop_name} AS property")
+            .return_literal(f"n.{safe_property_name(prop_name)} AS property")
             .get()
         )
         results = neptune.execute_open_cypher_query(openCypherQuery=query)
@@ -824,5 +825,5 @@ def generate_flow_collection_query(
     # Build the dict of set operations to carry out
     for _, c_ref, _, props in ref_names:
         for k, v in props.items():
-            set_dict[f"{c_ref}.`{k}`"] = v
+            set_dict[f"{c_ref}.{safe_property_name(k)}"] = v
     return query.set(set_dict)

--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -824,6 +824,5 @@ def generate_flow_collection_query(
     # Build the dict of set operations to carry out
     for _, c_ref, _, props in ref_names:
         for k, v in props.items():
-            # Add backticks around property names containing dots
             set_dict[f"{c_ref}.`{k}`"] = v
     return query.set(set_dict)

--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -825,6 +825,5 @@ def generate_flow_collection_query(
     for _, c_ref, _, props in ref_names:
         for k, v in props.items():
             # Add backticks around property names containing dots
-            prop_name = f"`{k}`" if "." in k else k
-            set_dict[f"{c_ref}.{prop_name}"] = v
+            set_dict[f"{c_ref}.`{k}`"] = v
     return query.set(set_dict)

--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -824,5 +824,7 @@ def generate_flow_collection_query(
     # Build the dict of set operations to carry out
     for _, c_ref, _, props in ref_names:
         for k, v in props.items():
-            set_dict[f"{c_ref}.{k}"] = v
+            # Add backticks around property names containing dots
+            prop_name = f"`{k}`" if "." in k else k
+            set_dict[f"{c_ref}.{prop_name}"] = v
     return query.set(set_dict)

--- a/layers/utils/utils.py
+++ b/layers/utils/utils.py
@@ -231,12 +231,14 @@ def serialise_neptune_obj(obj: dict, key_prefix: str = "") -> dict:
     """Return a new dict with properties of type dict/list serialised into string"""
     serialised = {}
     for k, v in obj.items():
+        # Add backticks around property names containing dots
+        prop_name = f"`{k}`" if "." in k else k
         if isinstance(v, (list, dict)):
-            serialised[f"{key_prefix}{constants.SERIALISE_PREFIX}{k}"] = (
+            serialised[f"{key_prefix}{constants.SERIALISE_PREFIX}{prop_name}"] = (
                 json.dumps(v, default=json_number) if v else None
             )
         else:
-            serialised[f"{key_prefix}{k}"] = v
+            serialised[f"{key_prefix}{prop_name}"] = v
     return serialised
 
 
@@ -275,9 +277,9 @@ def parse_api_gw_parameters(query_parameters: dict) -> tuple[defaultdict, list]:
             elif key == "tag_exists":
                 for tag_name, tag_exists in value.items():
                     if tag_exists:
-                        where_literals.append(f"t.{tag_name} IS NOT NULL")
+                        where_literals.append(f"t.`{tag_name}` IS NOT NULL")
                     else:
-                        where_literals.append(f"t.{tag_name} IS NULL")
+                        where_literals.append(f"t.`{tag_name}` IS NULL")
             else:
                 return_dict["properties"][key] = value
     return return_dict, where_literals

--- a/layers/utils/utils.py
+++ b/layers/utils/utils.py
@@ -231,7 +231,6 @@ def serialise_neptune_obj(obj: dict, key_prefix: str = "") -> dict:
     """Return a new dict with properties of type dict/list serialised into string"""
     serialised = {}
     for k, v in obj.items():
-        # Add backticks around property names containing dots
         if isinstance(v, (list, dict)):
             serialised[f"{key_prefix}`{constants.SERIALISE_PREFIX}{k}`"] = (
                 json.dumps(v, default=json_number) if v else None

--- a/layers/utils/utils.py
+++ b/layers/utils/utils.py
@@ -233,10 +233,10 @@ def serialise_neptune_obj(obj: dict, key_prefix: str = "") -> dict:
     for k, v in obj.items():
         if isinstance(v, (list, dict)):
             serialised[
-                f"{key_prefix}{safe_property_name(constants.SERIALISE_PREFIX + k)}"
+                f"{key_prefix}{opencypher_property_name(constants.SERIALISE_PREFIX + k)}"
             ] = (json.dumps(v, default=json_number) if v else None)
         else:
-            serialised[f"{key_prefix}{safe_property_name(k)}"] = v
+            serialised[f"{key_prefix}{opencypher_property_name(k)}"] = v
     return serialised
 
 
@@ -276,11 +276,11 @@ def parse_api_gw_parameters(query_parameters: dict) -> tuple[defaultdict, list]:
                 for tag_name, tag_exists in value.items():
                     if tag_exists:
                         where_literals.append(
-                            f"t.{safe_property_name(tag_name)} IS NOT NULL"
+                            f"t.{opencypher_property_name(tag_name)} IS NOT NULL"
                         )
                     else:
                         where_literals.append(
-                            f"t.{safe_property_name(tag_name)} IS NULL"
+                            f"t.{opencypher_property_name(tag_name)} IS NULL"
                         )
             else:
                 return_dict["properties"][key] = value
@@ -366,6 +366,6 @@ def get_default_value(value) -> dict | list | None:
 
 
 @tracer.capture_method(capture_response=False)
-def safe_property_name(name: str) -> str:
+def opencypher_property_name(name: str) -> str:
     """Returns a safe OpenCypher property name, wrapping in backticks and escaping existing backticks if needed."""
     return f"`{name.replace('`', '``')}`"

--- a/layers/utils/utils.py
+++ b/layers/utils/utils.py
@@ -232,13 +232,12 @@ def serialise_neptune_obj(obj: dict, key_prefix: str = "") -> dict:
     serialised = {}
     for k, v in obj.items():
         # Add backticks around property names containing dots
-        prop_name = f"`{k}`" if "." in k else k
         if isinstance(v, (list, dict)):
-            serialised[f"{key_prefix}{constants.SERIALISE_PREFIX}{prop_name}"] = (
+            serialised[f"{key_prefix}`{constants.SERIALISE_PREFIX}{k}`"] = (
                 json.dumps(v, default=json_number) if v else None
             )
         else:
-            serialised[f"{key_prefix}{prop_name}"] = v
+            serialised[f"{key_prefix}`{k}`"] = v
     return serialised
 
 

--- a/tests/unit/layers/utils/test_utils.py
+++ b/tests/unit/layers/utils/test_utils.py
@@ -284,7 +284,7 @@ class TestUtils:
             assert return_dict["tag_properties"][k] == v
 
         # Ensure tag_exists values are reflected in where literals
-        assert where_literals == ["t.y IS NOT NULL", "t.z IS NULL"]
+        assert where_literals == ["t.`y` IS NOT NULL", "t.`z` IS NULL"]
 
         # Ensure misc properties are included appropriately
         assert return_dict["properties"]["misc"] == query_parameters["misc"]

--- a/tests/unit/layers/utils/test_utils.py
+++ b/tests/unit/layers/utils/test_utils.py
@@ -239,13 +239,13 @@ class TestUtils:
 
     def test_serialise_neptune_obj(self):
         child_key = "child"
-        serialised_key = f"{constants.SERIALISE_PREFIX}{child_key}"
+        serialised_key = f"`{constants.SERIALISE_PREFIX}{child_key}`"
         input_dict = {"id": "123", child_key: {"hello": "world"}}
 
         result = utils.serialise_neptune_obj(input_dict)
 
         assert isinstance(result, dict)
-        assert result["id"] == input_dict["id"]
+        assert result["`id`"] == input_dict["id"]
         assert isinstance(result[serialised_key], str)
         assert json.loads(result[serialised_key]) == input_dict[child_key]
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This PR fixes a bug when a `.` is used (or any special character) in the name of a tag in TAMS. The OpenCypher queries are generated dynamically and therefore field names with dots were not being processed correctly. This PR encloses the field names in back ticks which is the OepnCypher method for using special characters in a field name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
