### PR TITLE
bugfix/flow format checks

### DIFF
--- a/functions/api_flows/app.py
+++ b/functions/api_flows/app.py
@@ -211,6 +211,13 @@ def put_flow_by_id(
             )  # 403
     except ValueError:
         existing_item = {}
+    if (
+        existing_item.get("format")
+        and existing_item.get("format") != flow.root.format.value
+    ):
+        raise BadRequestError(
+            "Bad request. The format of the flow cannot be changed."
+        )  # 400
     if not validate_flow_collection(flow_id, flow.root.flow_collection):
         raise BadRequestError("Bad request. Invalid flow collection.")  # 400
     # API spec states these fields should be ignored if given in a PUT request.

--- a/functions/api_flows/app.py
+++ b/functions/api_flows/app.py
@@ -211,8 +211,9 @@ def put_flow_by_id(
             )  # 403
     except ValueError:
         existing_item = {}
+    # Ensure format is not being changed but only for flow updates
     if (
-        existing_item.get("format")
+        existing_item.get("format") is not None
         and existing_item.get("format") != flow.root.format.value
     ):
         raise BadRequestError(

--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -8,6 +8,7 @@ import boto3
 import constants
 import cymple
 from aws_lambda_powertools import Tracer
+from aws_lambda_powertools.event_handler.exceptions import BadRequestError
 from cymple import QueryBuilder
 from deepdiff import DeepDiff
 from schema import Flowcollection, Source
@@ -775,8 +776,14 @@ def validate_flow_collection(flow_id: str, flow_collection: Flowcollection):
 @tracer.capture_method(capture_response=False)
 def merge_source_flow(flow_dict: dict, existing_dict: dict) -> dict:
     """Perform an OpenCypher Merge operation on the supplied TAMS Source/Flow record"""
-    # Check if supplied source already exists, create if not
-    if not check_node_exists("source", flow_dict["source_id"]):
+    # Check if supplied source already exists, create if not. Raise error if format does not match
+    try:
+        existing_source = query_node("source", flow_dict["source_id"])
+        if existing_source["format"] != flow_dict["format"]:
+            raise BadRequestError(
+                "Bad request. The format of the flow must match the specified source."
+            )  # 400
+    except ValueError:
         source: Source = Source(**flow_dict)
         source.id = flow_dict["source_id"]
         source_dict = model_dump(source)

--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -779,7 +779,7 @@ def merge_source_flow(flow_dict: dict, existing_dict: dict) -> dict:
     # Check if supplied source already exists, create if not. Raise error if format does not match
     try:
         existing_source = query_node("source", flow_dict["source_id"])
-        if existing_source["format"] != flow_dict["format"]:
+        if existing_source.get("format") != flow_dict.get("format"):
             raise BadRequestError(
                 "Bad request. The format of the flow must match the specified source."
             )  # 400


### PR DESCRIPTION
*Issue #, if available:*
#51 
#50 

*Description of changes:*
This PR fixes 2 bugs:
- When updating a flow it should not be possible to change the format of the flow.
- When creating a flow it should enforce the supplied source_id has the same format as the flow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
