### PR TITLE
Feat/webhooks to neptune

### DIFF
--- a/api/build/openapi.yaml
+++ b/api/build/openapi.yaml
@@ -2848,9 +2848,6 @@ components:
         api_key_name:
           description: The HTTP header name that is added to the event POST
           type: string
-        api_key_value:
-          description: The value that the HTTP header 'api_key_name' will be set to
-          type: string
         events:
           description: List of event types to receive
           type: array

--- a/functions/api_service/app.py
+++ b/functions/api_service/app.py
@@ -159,9 +159,3 @@ def lambda_handler(event: dict, context: LambdaContext) -> dict:
 @app.exception_handler(RequestValidationError)
 def handle_validation_error(ex: RequestValidationError):
     raise BadRequestError(ex.errors())  # 400
-
-
-@tracer.capture_method(capture_response=False)
-def model_dump_webhook(webhook: Webhook):
-    """Custom model dump to retain empty values from webhook"""
-    return webhook.model_dump(by_alias=True, exclude_unset=True)

--- a/functions/webhooks_delivery/app.py
+++ b/functions/webhooks_delivery/app.py
@@ -14,7 +14,7 @@ from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSEvent, SQS
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from requests import Session
 from requests.adapters import HTTPAdapter, Retry
-from schema import Flow, Flowsegment, Source, Webhook
+from schema import Flow, Flowsegment, Source, Webhookpost
 from utils import model_dump
 
 tracer = Tracer()
@@ -28,7 +28,7 @@ def record_handler(record: SQSRecord) -> None:
     """Processes a single SQS record"""
     body = json.loads(record.body)
     event = EventBridgeEvent(body["event"])
-    webhook = Webhook(**body["item"])
+    webhook = Webhookpost(**body["item"])
     get_urls = body["get_urls"]
     retries = Retry(
         total=5,

--- a/layers/utils/constants.py
+++ b/layers/utils/constants.py
@@ -17,6 +17,7 @@ RETURN_LITERAL = {
     "source": "source {.*, tags: t {.*}, source_collection: collect(DISTINCT c {.*, id: sc.id}), collected_by: collect(DISTINCT cb.id)}",
     "flow": "flow {.*, source_id: s.id, essence_parameters: e {.*}, tags: t {.*}, flow_collection: collect(DISTINCT c {.*, id: fc.id}), collected_by: collect(DISTINCT cb.id)}",
     "delete_request": "delete_request {.*, error: CASE WHEN e.type IS NULL THEN NULL ELSE e {.*} END}",
+    "webhook": "webhook {.*}",
 }
 PRESIGNED_URL_EXPIRES_IN = 3600
 SERVICE_INFO_ID = "1"

--- a/layers/utils/dynamodb.py
+++ b/layers/utils/dynamodb.py
@@ -29,7 +29,6 @@ dynamodb = boto3.resource("dynamodb")
 service_table = dynamodb.Table(os.environ.get("SERVICE_TABLE", ""))
 segments_table = dynamodb.Table(os.environ.get("SEGMENTS_TABLE", ""))
 storage_table = dynamodb.Table(os.environ.get("STORAGE_TABLE", ""))
-webhooks_table = dynamodb.Table(os.environ.get("WEBHOOKS_TABLE", ""))
 
 
 class TimeRangeBoundary(Enum):

--- a/layers/utils/neptune.py
+++ b/layers/utils/neptune.py
@@ -12,7 +12,7 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler.exceptions import BadRequestError
 from cymple import QueryBuilder
 from deepdiff import DeepDiff
-from schema import Flowcollection, Source, Webhook
+from schema import Flowcollection, Source, Webhookpost
 from utils import (
     deserialise_neptune_obj,
     filter_dict,
@@ -963,6 +963,6 @@ def get_matching_webhooks(event):
     query = query.return_literal(constants.RETURN_LITERAL["webhook"]).get()
     results = execute_open_cypher_query(query)
     return [
-        Webhook(**deserialise_neptune_obj(result["webhook"]))
+        Webhookpost(**deserialise_neptune_obj(result["webhook"]))
         for result in results["results"]
     ]

--- a/layers/utils/schema.py
+++ b/layers/utils/schema.py
@@ -261,9 +261,6 @@ class Webhook(BaseModel):
     api_key_name: Optional[str] = Field(
         None, description="The HTTP header name that is added to the event POST"
     )
-    api_key_value: Optional[str] = Field(
-        None, description="The value that the HTTP header 'api_key_name' will be set to"
-    )
     events: List[str] = Field(..., description="List of event types to receive")
     flow_ids: Optional[
         List[

--- a/template.yaml
+++ b/template.yaml
@@ -222,41 +222,6 @@ Resources:
           Projection:
             ProjectionType: ALL
 
-  WebhooksTable:
-    DeletionPolicy: RetainExceptOnCreate
-    UpdateReplacePolicy: Retain
-    Type: AWS::DynamoDB::Table
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W74
-            reason: Encryption not required
-          - id: W78
-            reason: Backup not required
-    Properties:
-      BillingMode: PAY_PER_REQUEST
-      PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: True
-      AttributeDefinitions:
-        - AttributeName: event
-          AttributeType: S
-        - AttributeName: url
-          AttributeType: S
-      KeySchema:
-        - AttributeName: event
-          KeyType: HASH
-        - AttributeName: url
-          KeyType: RANGE
-      GlobalSecondaryIndexes:
-        - IndexName: url-index
-          KeySchema:
-            - AttributeName: url
-              KeyType: HASH
-            - AttributeName: event
-              KeyType: RANGE
-          Projection:
-            ProjectionType: KEYS_ONLY
-
   FlowStorageTable:
     DeletionPolicy: RetainExceptOnCreate
     UpdateReplacePolicy: Retain
@@ -459,7 +424,6 @@ Resources:
           POWERTOOLS_METRICS_NAMESPACE: TAMS
           NEPTUNE_ENDPOINT: !GetAtt NeptuneStack.Outputs.Endpoint
           SERVICE_TABLE: !Ref ServiceTable
-          WEBHOOKS_TABLE: !Ref WebhooksTable
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -472,12 +436,13 @@ Resources:
                 - !GetAtt ServiceTable.Arn
             - Effect: Allow
               Action:
-                - dynamodb:Scan
-                - dynamodb:Query
-                - dynamodb:BatchWriteItem
-              Resource:
-                - !GetAtt WebhooksTable.Arn
-                - !Sub ${WebhooksTable.Arn}/index/url-index
+                - neptune-db:ReadDataViaQuery
+                - neptune-db:WriteDataViaQuery
+                - neptune-db:DeleteDataViaQuery
+              Resource: !Sub arn:${AWS::Partition}:neptune-db:${AWS::Region}:${AWS::AccountId}:${NeptuneStack.Outputs.ClusterResourceId}/*
+              Condition:
+                StringEquals:
+                  neptune-db:QueryLanguage: OpenCypher
       Events:
         headRoot:
           Type: Api
@@ -1612,8 +1577,8 @@ Resources:
           POWERTOOLS_LOG_LEVEL: INFO
           POWERTOOLS_SERVICE_NAME: tams-webhooks
           POWERTOOLS_METRICS_NAMESPACE: TAMS
+          NEPTUNE_ENDPOINT: !GetAtt NeptuneStack.Outputs.Endpoint
           SERVICE_TABLE: !Ref ServiceTable
-          WEBHOOKS_TABLE: !Ref WebhooksTable
           WEBHOOKS_QUEUE_URL: !Ref WebhooksDeliveryQueue
       Policies:
         - Version: "2012-10-17"
@@ -1621,14 +1586,16 @@ Resources:
             - Effect: Allow
               Action:
                 - dynamodb:Query
-              Resource:
-                - !GetAtt WebhooksTable.Arn
-            - Effect: Allow
-              Action:
-                - dynamodb:Query
                 - dynamodb:GetItem
               Resource:
                 - !GetAtt ServiceTable.Arn
+            - Effect: Allow
+              Action:
+                - neptune-db:ReadDataViaQuery
+              Resource: !Sub arn:${AWS::Partition}:neptune-db:${AWS::Region}:${AWS::AccountId}:${NeptuneStack.Outputs.ClusterResourceId}/*
+              Condition:
+                StringEquals:
+                  neptune-db:QueryLanguage: OpenCypher
             - Effect: Allow
               Action:
                 - s3:GetObject
@@ -2005,9 +1972,6 @@ Outputs:
 
   FlowStorageTable:
     Value: !Ref FlowStorageTable
-
-  WebhooksTable:
-    Value: !Ref WebhooksTable
 
   CleanupS3QueueUrl:
     Value: !Ref CleanupS3Queue

--- a/tests/acceptance/test_01_service.py
+++ b/tests/acceptance/test_01_service.py
@@ -130,14 +130,17 @@ def test_Register_Webhook_URL_POST_201_create(api_client_cognito):
     webhook = {
         "url": "https://hook.example.com",
         "api_key_name": "Authorization",
-        "api_key_value": "Bearer 21238dksdjqwpqscj9",
         "events": ["flows/created", "flows/updated", "flows/deleted"],
+    }
+    webhook_post = {
+        **webhook,
+        "api_key_value": "Bearer 21238dksdjqwpqscj9",
     }
     # Act
     response = api_client_cognito.request(
         "POST",
         path,
-        json=webhook,
+        json=webhook_post,
     )
     response_headers_lower = {k.lower(): v for k, v in response.headers.items()}
     # Assert
@@ -153,14 +156,17 @@ def test_Register_Webhook_URL_POST_201_update(api_client_cognito):
     webhook = {
         "url": "https://hook.example.com",
         "api_key_name": "Authorization",
-        "api_key_value": "Bearer 12138dksdjqwpqscj9",
         "events": ["flows/created", "flows/updated"],
+    }
+    webhook_post = {
+        **webhook,
+        "api_key_value": "Bearer 21238dksdjqwpqscj9",
     }
     # Act
     response = api_client_cognito.request(
         "POST",
         path,
-        json=webhook,
+        json=webhook_post,
     )
     response_headers_lower = {k.lower(): v for k, v in response.headers.items()}
     # Assert

--- a/tests/acceptance/test_05_delete-requests.py
+++ b/tests/acceptance/test_05_delete-requests.py
@@ -538,16 +538,6 @@ def test_Flow_Delete_Request_Details_GET_404(api_client_cognito, id_404):
     )
 
 
-def test_Webhooks_Table_Empty(session, region, stack):
-    # Arrange
-    dynamodb = session.resource("dynamodb", region_name=region)
-    webhooks_table = dynamodb.Table(stack["outputs"]["WebhooksTable"])
-    # Act
-    scan = webhooks_table.scan(Select="COUNT")
-    # Assert
-    assert 0 == scan["Count"]
-
-
 def test_FlowSegments_Table_Empty(session, region, stack):
     # Arrange
     dynamodb = session.resource("dynamodb", region_name=region)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,7 +15,6 @@ os.environ["SEGMENTS_TABLE"] = "segments-table"
 os.environ["STORAGE_TABLE"] = "storage-table"
 os.environ["USER_POOL_ID"] = "123"
 os.environ["WEBHOOKS_QUEUE_URL"] = "test-queue"
-os.environ["WEBHOOKS_TABLE"] = "webhooks-table"
 
 logger = logging.getLogger(__name__)
 builder = ConditionExpressionBuilder()


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This PR moves the "webhook" entity from a dedicated DynamoDB table in the solution to a separate node type in the existing Neptune database. The DynamoDB implementation came with limitations as to how the Webhooks could be managed so moving to Neptune gives us more options for future planned enhancements of Webhooks. So this PR is really being done in preparation for that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
