### PR TITLE
fix unexpected pagination headers in segment endpoint requests

### DIFF
--- a/functions/api_flow_segments/app.py
+++ b/functions/api_flow_segments/app.py
@@ -136,7 +136,8 @@ def get_flow_segments_by_id(
                     TimeRange.from_str(items[-1]["timerange"])
                 )
             )
-    if "LastEvaluatedKey" in query:
+    has_more_results = "LastEvaluatedKey" in query and len(items) == args["Limit"]
+    if has_more_results:
         next_key = (
             items[-1]["timerange_end"]
             if items
@@ -145,7 +146,7 @@ def get_flow_segments_by_id(
         custom_headers["X-Paging-NextKey"] = str(next_key)
         custom_headers["Link"] = generate_link_url(app.current_event, str(next_key))
     # Set Paging Limit header if paging limit being used is not the one specified
-    if "LastEvaluatedKey" in query or param_limit != args["Limit"]:
+    if has_more_results or param_limit != args["Limit"]:
         custom_headers["X-Paging-Limit"] = str(args["Limit"])
     custom_headers["X-Paging-Count"] = str(len(items))
     custom_headers["X-Paging-Reverse-Order"] = str(reverse_order)


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Before this change whenever last-evaluated-key was present in the DDB response we set some pagination specific headers.
This PR fixes that logic so that only if there are more results than requested do we set these headers.

Prior to this if we used limit to retrieve a fixed number of results and this number was returned then we would get pagination headers which made no sense.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
