### PR TITLE
fix bug with Cognito Stack creation logic

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -80,11 +80,9 @@ Conditions:
 
   CreateWaf: !Equals [!Ref DeployWaf, "Yes"]
 
-  CreateCognito: !Equals [!Ref JwtIssuerUrl, ""]
-
   CreateLambdaAuthorizer: !Equals [!Ref LambdaAuthorizerArn, ""]
 
-  CognitoAndLambdaAuthorizer: !And [!Condition CreateCognito, !Condition CreateLambdaAuthorizer]
+  CreateCognito: !And [!Equals [!Ref JwtIssuerUrl, ""], !Condition CreateLambdaAuthorizer]
 
 Transform: AWS::Serverless-2016-10-31
 
@@ -156,7 +154,7 @@ Resources:
               - cognito-idp:AdminGetUser
               - cognito-idp:DescribeUserPoolClient
             Resource: !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoStack.Outputs.UserPoolId}
-    Condition: CognitoAndLambdaAuthorizer
+    Condition: CreateCognito
 
   Api:
     Type: AWS::Serverless::Api


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This PR fixes the logic for when to deploy the Cognito Stack. Prior to this PR the logic was incorrect as it still created a Cognito stack when a LambdaAuthorizerArn parameter was supplied which it should not have.
It should now only create the Cognito Stack when NEITHER the JWTUrl or the LambdaAuthoriserArn are supplied.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
